### PR TITLE
Add tests to check if a macro works inside let-nom

### DIFF
--- a/test/cljc/de/otto/nom/core_test.cljc
+++ b/test/cljc/de/otto/nom/core_test.cljc
@@ -336,6 +336,11 @@
             (is (every? #(= [::nom/anomaly :div-by-zero] %)
                         r))))))))
 
+(deftest let-nom-should-work-with-macros
+  (testing "When using a macro in a let-nom binding it should work like in a normal let"
+    (nom/let-nom [foo (-> 1 (+ 1))]
+                 (is foo 2))))
+
 ;; let-nom>
 
 (deftest let-nom>-should-work-like-normal-let-if-no-anomaly
@@ -360,6 +365,11 @@
                     not executed, even if they do not depend on an anomaly"
             (is (= [::nom/anomaly :missing-node]
                    r))))))))
+
+(deftest let-nom>-should-work-with-macros
+  (testing "When using a macro in a let-nom> binding it should work like in a normal let"
+    (nom/let-nom> [foo (-> 1 (+ 1))]
+                  (is foo 2))))
 
 ;; nom->
 


### PR DESCRIPTION
Here's a test to check for the problem mentioned in #1. Obviously it fails at the moment as currently macros inside `let-nom` bindings cause a syntax error.